### PR TITLE
v0.6: Apple Silicon universal build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+*.app.zip

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,65 @@
 APP=WhyAwake
-LIBDIRS=../go-pmset ../go-caffeinate
+EXE=whyawake
+VERSION=v0.6
 IDENTITY=Developer ID Application: Rational Creation LLC (AP2AEA9WAW)
 IDENTIFIER=whyawake.caseymrm.github.com
 
-include $(GOPATH)/src/github.com/caseymrm/menuet/menuet.mk
+SDK=$(shell xcrun --sdk macosx --show-sdk-path)
+BUILD=build
+APPDIR=$(APP).app
+MACOS=$(APPDIR)/Contents/MacOS
+
+# menuet's UNUserNotificationCenter requires macOS 10.14+; arm64 requires 11+
+AMD64_MIN=10.14
+ARM64_MIN=11.0
+
+GO=go
+GOFLAGS=-trimpath -ldflags="-s -w"
+
+.PHONY: all amd64 arm64 universal app sign notarize zip release clean
+
+all: app
+
+$(BUILD):
+	mkdir -p $(BUILD)
+
+amd64: $(BUILD)
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 \
+	  CGO_CFLAGS="-mmacosx-version-min=$(AMD64_MIN) -isysroot $(SDK)" \
+	  CGO_LDFLAGS="-mmacosx-version-min=$(AMD64_MIN)" \
+	  $(GO) build $(GOFLAGS) -o $(BUILD)/$(EXE)-amd64 .
+
+arm64: $(BUILD)
+	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 \
+	  CGO_CFLAGS="-mmacosx-version-min=$(ARM64_MIN) -isysroot $(SDK)" \
+	  CGO_LDFLAGS="-mmacosx-version-min=$(ARM64_MIN)" \
+	  $(GO) build $(GOFLAGS) -o $(BUILD)/$(EXE)-arm64 .
+
+universal: amd64 arm64
+	lipo -create -output $(BUILD)/$(EXE) $(BUILD)/$(EXE)-amd64 $(BUILD)/$(EXE)-arm64
+	lipo -info $(BUILD)/$(EXE)
+
+app: universal
+	cp $(BUILD)/$(EXE) $(MACOS)/$(EXE)
+
+sign: app
+	codesign --force --options runtime --timestamp \
+	  --sign "$(IDENTITY)" $(APPDIR)
+
+zip:
+	rm -f $(BUILD)/$(APP).app.zip
+	ditto -c -k --keepParent $(APPDIR) $(BUILD)/$(APP).app.zip
+
+# Requires a keychain profile named AC_NOTARY: xcrun notarytool store-credentials AC_NOTARY
+notarize: sign zip
+	xcrun notarytool submit $(BUILD)/$(APP).app.zip --keychain-profile AC_NOTARY --wait
+	xcrun stapler staple $(APPDIR)
+	$(MAKE) zip
+
+release: zip
+	gh release create $(VERSION) $(BUILD)/$(APP).app.zip \
+	  --title "$(VERSION) — Apple Silicon universal build" \
+	  --notes-file RELEASE_NOTES.md
+
+clean:
+	rm -rf $(BUILD)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,22 @@
+## v0.6 — Apple Silicon universal build
+
+First release supporting Apple Silicon natively. Universal binary (`x86_64` + `arm64`).
+
+### What changed
+- Universal `darwin/amd64` + `darwin/arm64` binary via `lipo` (was: `amd64` only).
+- Modernized build to Go modules; new `Makefile` handles both arches and packaging.
+- Picked up [`menuet` v1.1.0](https://github.com/caseymrm/menuet/releases/tag/v1.1.0), which migrated notifications off the deprecated `NSUserNotificationCenter` to `UNUserNotificationCenter` (closes the long-standing menuet issue #18).
+- `LSMinimumSystemVersion` bumped to **macOS 10.14** (the floor required by the `UserNotifications` framework).
+
+### Gatekeeper warning
+This build is **unsigned** (ad-hoc only) and **not notarized**. On first launch macOS will refuse to open it. To open:
+
+1. Right-click `WhyAwake.app` → **Open** → confirm in the dialog, **or**
+2. Run `xattr -dr com.apple.quarantine /Applications/WhyAwake.app` after copying it to `/Applications`.
+
+A signed + notarized build will come back once the Developer ID identity is restored.
+
+### Install
+- Download `WhyAwake.app.zip` below.
+- Unzip, drag `WhyAwake.app` to `/Applications`.
+- Launch (see Gatekeeper note above).

--- a/WhyAwake.app/Contents/Info.plist
+++ b/WhyAwake.app/Contents/Info.plist
@@ -13,7 +13,7 @@
   <key>CFBundleName</key>
   <string>WhyAwake</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.1</string>
+  <string>0.6</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundlePackageType</key>
@@ -21,7 +21,9 @@
   <key>IFMajorVersion</key>
   <integer>0</integer>
   <key>IFMinorVersion</key>
-  <integer>1</integer>
+  <integer>6</integer>
+  <key>LSMinimumSystemVersion</key>
+  <string>10.14</string>
   <key>NSHighResolutionCapable</key><true/>
   <key>NSSupportsAutomaticGraphicsSwitching</key><true/>
 </dict>

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/caseymrm/whyawake
+
+go 1.26.4
+
+require (
+	github.com/caseymrm/go-caffeinate v1.0.0
+	github.com/caseymrm/go-pmset v1.0.0
+	github.com/caseymrm/menuet v1.1.0
+)
+
+require github.com/caseymrm/askm v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/caseymrm/askm v1.0.0 h1:Ff5QN5GwuyCzg63++hU1jV+1JVYHYd0sw6KUkVd2GiQ=
+github.com/caseymrm/askm v1.0.0/go.mod h1:raj+vtH8SsGkuSg1/970qaONNyNlIb7zFv2LDVk6j+U=
+github.com/caseymrm/go-caffeinate v1.0.0 h1:fbHfzQkNK6l/WqC9k5ZXUE2+P5Iwy34kPtxBpBVI8lA=
+github.com/caseymrm/go-caffeinate v1.0.0/go.mod h1:gXx40jOf0W/tasszHsTf5Uxe6+zS9+5SMyBudE75Pzs=
+github.com/caseymrm/go-pmset v1.0.0 h1:iXc5GlLSqdR0C0GW9nvxvF02ynUkbeVNhAPoYPW+psg=
+github.com/caseymrm/go-pmset v1.0.0/go.mod h1:MYha1Z8OJEvuLrM+7xZGkPGwpkzJ5uZ+M89hJkQoFD4=
+github.com/caseymrm/menuet v1.1.0 h1:t40I1SDjKmV+9ChftbiUpOwaKc76ZWhOx4Umy1ehkjs=
+github.com/caseymrm/menuet v1.1.0/go.mod h1:Vdn4A7NdnGnx9CwlhyhAn4ii5xrpQkvaONdzpTyJ4j0=

--- a/whyawake.go
+++ b/whyawake.go
@@ -136,7 +136,7 @@ func main() {
 	app.Name = "Why Awake?"
 	app.Label = "com.github.caseymrm.whyawake"
 	app.Children = menuItems
-	app.AutoUpdate.Version = "v0.5"
+	app.AutoUpdate.Version = "v0.6"
 	app.AutoUpdate.Repo = "caseymrm/whyawake"
 	app.RunApplication()
 }


### PR DESCRIPTION
## Summary
- First Apple Silicon native release. Universal binary (`x86_64` + `arm64`) built via `lipo`.
- Modernized to Go modules; new self-contained `Makefile` handles both arches and packaging.
- Picks up `menuet` v1.1.0 (UNUserNotificationCenter migration — closes menuet#18 indirectly), `go-pmset` v1.0.0, `go-caffeinate` v1.0.0.
- `LSMinimumSystemVersion` bumped to 10.14 to match the `UserNotifications` framework floor.

## Notes
- Ad-hoc signed (no Developer ID Application identity available in this keychain). Release notes include the Gatekeeper unquarantine workaround.
- AutoUpdate.Version bumped to `v0.6` so existing v0.5 installs will see the update.

## Test plan
- [x] Build amd64 + arm64 — both compile cleanly with the new menuet
- [x] `lipo -info` confirms `x86_64 arm64` in the bundled binary
- [x] Smoke-test: `open WhyAwake.app` launches and stays running on Apple Silicon
- [ ] Manual verify on amd64 hardware (not available in this env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)