### PR TITLE
v0.8: default left-click action (closes #2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP=WhyAwake
 EXE=whyawake
-VERSION=v0.7
+VERSION=v0.8
 IDENTITY=Developer ID Application: Rational Creation LLC (AP2AEA9WAW)
 IDENTIFIER=whyawake.caseymrm.github.com
 
@@ -58,7 +58,7 @@ notarize: sign zip
 
 release: zip
 	gh release create $(VERSION) $(BUILD)/$(APP).app.zip \
-	  --title "$(VERSION) — Until I close the lid" \
+	  --title "$(VERSION) — Default left-click action" \
 	  --notes-file RELEASE_NOTES.md
 
 clean:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,21 +1,17 @@
-## v0.7 — "Until I close the lid"
+## v0.8 — Default left-click action
 
-New sleep-prevention option: **Until I close the lid**. Pick it from the menu, get on with your work, and the moment you close the lid the app stops caffeinating and lets the system sleep normally — no timer to guess at, no manual deactivation.
+Pick a default duration from the new **Left-click** submenu, and from then on a single left-click on the menubar icon toggles caffeinate at that duration — no menu, no submenu. Right-click (or Ctrl-click) still opens the full menu.
 
-### How it works
-A new sister library, [`caseymrm/go-clamshell`](https://github.com/caseymrm/go-clamshell), subscribes to IOKit's `kIOPMMessageClamshellStateChange` push notification (no polling — the kernel tells us the moment the lid moves). When the state flips to closed *and* you're in lid mode, whyawake calls `caffeinate.Stop()` and the deferred sleep proceeds.
+### What changed
+- New **"Left-click: …"** menu section. Choices: Off · Until I close the lid · Indefinitely · 10 / 30 / 60 / 180 min. Stored in NSUserDefaults; the current choice is shown in the parent label and persists across launches.
+- When a default is set, left-click *toggles*: if the Mac is being kept awake, the click cancels it; otherwise it starts a new session at the chosen duration. (Accidentally caffeinated → one click to undo.)
+- Picks up `menuet` v2.1.1 (new `Application.Clicked` field, plus the v2 Go module path fix).
+- Closes #2.
 
-### Other
-- Picks up `go-clamshell` v1.0.1.
-- Closes #1.
-
-### Gatekeeper warning
-This build is still **unsigned** (ad-hoc only). To open:
-
-1. Right-click `WhyAwake.app` → **Open** → confirm in the dialog, **or**
-2. Run `xattr -dr com.apple.quarantine /Applications/WhyAwake.app` after copying to `/Applications`.
+### Gatekeeper
+Still **unsigned** (ad-hoc only).
+1. Right-click `WhyAwake.app` → **Open** → confirm, **or**
+2. `xattr -dr com.apple.quarantine /Applications/WhyAwake.app` after copying to `/Applications`.
 
 ### Install
-- Download `WhyAwake.app.zip` below.
-- Unzip, drag to `/Applications`.
-- Launch (see Gatekeeper note above).
+Download `WhyAwake.app.zip` → unzip → drag to `/Applications` → launch (see Gatekeeper note).

--- a/WhyAwake.app/Contents/Info.plist
+++ b/WhyAwake.app/Contents/Info.plist
@@ -13,7 +13,7 @@
   <key>CFBundleName</key>
   <string>WhyAwake</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.7</string>
+  <string>0.8</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundlePackageType</key>
@@ -21,7 +21,7 @@
   <key>IFMajorVersion</key>
   <integer>0</integer>
   <key>IFMinorVersion</key>
-  <integer>7</integer>
+  <integer>8</integer>
   <key>LSMinimumSystemVersion</key>
   <string>10.14</string>
   <key>NSHighResolutionCapable</key><true/>

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/caseymrm/go-caffeinate v1.0.0
 	github.com/caseymrm/go-clamshell v1.0.1
 	github.com/caseymrm/go-pmset v1.0.0
-	github.com/caseymrm/menuet v1.1.0
+	github.com/caseymrm/menuet/v2 v2.1.1
 )
 
 require github.com/caseymrm/askm v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,5 @@ github.com/caseymrm/go-clamshell v1.0.1 h1:BWUf0uIPyT/aQ+QNnKOuJeI6iwvW2xMxfiPGx
 github.com/caseymrm/go-clamshell v1.0.1/go.mod h1:EH815Qd3cw5WHTqwn4i+TtjTns9tlpn0v/Nf5PIhu/0=
 github.com/caseymrm/go-pmset v1.0.0 h1:iXc5GlLSqdR0C0GW9nvxvF02ynUkbeVNhAPoYPW+psg=
 github.com/caseymrm/go-pmset v1.0.0/go.mod h1:MYha1Z8OJEvuLrM+7xZGkPGwpkzJ5uZ+M89hJkQoFD4=
-github.com/caseymrm/menuet v1.1.0 h1:t40I1SDjKmV+9ChftbiUpOwaKc76ZWhOx4Umy1ehkjs=
-github.com/caseymrm/menuet v1.1.0/go.mod h1:Vdn4A7NdnGnx9CwlhyhAn4ii5xrpQkvaONdzpTyJ4j0=
+github.com/caseymrm/menuet/v2 v2.1.1 h1:9Iv0bP40xYHZJySwIDljrWEGYf2bNd8J1NMgWNED11k=
+github.com/caseymrm/menuet/v2 v2.1.1/go.mod h1:ZFPTrTUdPWdVFjb6FQPbbDNtYD0X3/svM+QTkMYFHjM=

--- a/leftclick.go
+++ b/leftclick.go
@@ -1,0 +1,109 @@
+package main
+
+import "github.com/caseymrm/menuet/v2"
+
+// Persisted as NSUserDefaults integer "leftClickDuration". 0 (the default
+// for a missing key) means "left-click opens the menu, like before". The
+// other sentinel (-2 = indefinite) shifts preventSleep's 0=indefinite out
+// of the way so we can reserve 0 for "off" at the storage layer.
+const (
+	leftClickDefaultsKey = "leftClickDuration"
+
+	storedOff        = 0
+	storedLid        = -1
+	storedIndefinite = -2
+)
+
+type leftClickChoice struct {
+	label  string
+	stored int
+}
+
+var leftClickChoices = []leftClickChoice{
+	{"Off", storedOff},
+	{"Until I close the lid", storedLid},
+	{"Indefinitely", storedIndefinite},
+	{"10 minutes", 10},
+	{"30 minutes", 30},
+	{"1 hour", 60},
+	{"3 hours", 180},
+}
+
+// readLeftClickStored returns the raw persisted value.
+func readLeftClickStored() int {
+	return menuet.Defaults().Integer(leftClickDefaultsKey)
+}
+
+// leftClickMinutes converts the persisted sentinel into the integer
+// preventSleep expects: lidMode, 0 (indefinite), or N minutes.
+// The bool reports whether left-click is wired up at all.
+func leftClickMinutes() (minutes int, enabled bool) {
+	switch v := readLeftClickStored(); v {
+	case storedOff:
+		return 0, false
+	case storedLid:
+		return lidMode, true
+	case storedIndefinite:
+		return 0, true
+	default:
+		return v, true
+	}
+}
+
+func setLeftClickStored(stored int) {
+	menuet.Defaults().SetInteger(leftClickDefaultsKey, stored)
+	refreshLeftClickHandler()
+}
+
+// refreshLeftClickHandler sets or clears menuet's top-level click handler
+// to match the current setting. Safe to call from any goroutine — menuet
+// reads App().Clicked on each click.
+func refreshLeftClickHandler() {
+	_, enabled := leftClickMinutes()
+	if enabled {
+		menuet.App().Clicked = toggleLeftClick
+	} else {
+		menuet.App().Clicked = nil
+	}
+}
+
+// toggleLeftClick is what menuet calls on a top-level left click. If sleep
+// prevention is already running, this cancels it; otherwise it starts a new
+// session at the configured default duration.
+func toggleLeftClick() {
+	if preventingSleep() {
+		cancelSleepPrevention()
+		return
+	}
+	minutes, enabled := leftClickMinutes()
+	if !enabled {
+		return
+	}
+	go preventSleep(minutes)
+}
+
+// leftClickDefaultLabel produces the parent menu item's text so the current
+// choice is visible without opening the submenu.
+func leftClickDefaultLabel() string {
+	current := readLeftClickStored()
+	for _, c := range leftClickChoices {
+		if c.stored == current {
+			return "Left-click: " + c.label
+		}
+	}
+	return "Left-click: Off"
+}
+
+func leftClickDefaultMenu() []menuet.MenuItem {
+	current := readLeftClickStored()
+	items := make([]menuet.MenuItem, len(leftClickChoices))
+	for i, c := range leftClickChoices {
+		stored := c.stored
+		items[i] = menuet.MenuItem{
+			Text:    c.label,
+			State:   current == stored,
+			Clicked: func() { setLeftClickStored(stored) },
+		}
+	}
+	return items
+}

--- a/sleep.go
+++ b/sleep.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/caseymrm/go-caffeinate"
-	"github.com/caseymrm/menuet"
+	"github.com/caseymrm/menuet/v2"
 )
 
 // lidMode is a sentinel value for cafMinutes meaning "keep awake until the

--- a/whyawake.go
+++ b/whyawake.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/caseymrm/go-clamshell"
 	"github.com/caseymrm/go-pmset"
-	"github.com/caseymrm/menuet"
+	"github.com/caseymrm/menuet/v2"
 )
 
 var sleepKeywords = map[string]bool{
@@ -87,6 +87,15 @@ func menuItems() []menuet.MenuItem {
 	})
 	items = append(items, sleepOptions()...)
 
+	items = append(items, menuet.MenuItem{
+		Type: menuet.Separator,
+	})
+	items = append(items, menuet.MenuItem{
+		Text:     leftClickDefaultLabel(),
+		FontSize: 12,
+		Children: leftClickDefaultMenu,
+	})
+
 	return items
 }
 
@@ -148,7 +157,8 @@ func main() {
 	app.Name = "Why Awake?"
 	app.Label = "com.github.caseymrm.whyawake"
 	app.Children = menuItems
-	app.AutoUpdate.Version = "v0.7"
+	app.AutoUpdate.Version = "v0.8"
 	app.AutoUpdate.Repo = "caseymrm/whyawake"
+	refreshLeftClickHandler()
 	app.RunApplication()
 }


### PR DESCRIPTION
## Summary
- Adds a **Left-click** submenu where users pick a default duration. When set, left-clicking the menubar icon toggles caffeinate at that duration; right-click (or Ctrl-click) still opens the full menu.
- Toggle semantics: if already caffeinating, the click cancels; otherwise starts a new session at the chosen duration. An accidentally activated state is now undoable in one click.
- Picks up [menuet v2.1.1](https://github.com/caseymrm/menuet/releases/tag/v2.1.1) — the new `Application.Clicked` field plus the v2 Go module path fix. Imports updated to `.../menuet/v2`.
- Closes #2.

## Implementation notes
- Setting persisted in NSUserDefaults under `leftClickDuration`. Sentinels: `0` = off (default for missing key), `-1` = lid, `-2` = indefinite, `N>0` = minutes. Decoded by `leftClickMinutes()` so `preventSleep` keeps its existing semantics.
- `refreshLeftClickHandler()` flips `menuet.App().Clicked` between `toggleLeftClick` and `nil` based on the setting; called at startup and after each submenu change. menuet reads the field per-click, so no menu rebuild is needed.
- Parent menu label shows the current choice (e.g. "Left-click: 10 minutes").

## Test plan
- [x] Universal build: `lipo -info` → x86_64 arm64
- [x] App launches and stays running on Apple Silicon
- [ ] End-to-end click toggle (manual, post-merge): set default → menubar click activates → menubar click cancels
- [ ] Persistence across launches (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)