### PR TITLE
v0.9: bump menuet to v2.2.0 (MenuItem interface)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP=WhyAwake
 EXE=whyawake
-VERSION=v0.8
+VERSION=v0.9
 IDENTITY=Developer ID Application: Rational Creation LLC (AP2AEA9WAW)
 IDENTIFIER=whyawake.caseymrm.github.com
 
@@ -58,7 +58,7 @@ notarize: sign zip
 
 release: zip
 	gh release create $(VERSION) $(BUILD)/$(APP).app.zip \
-	  --title "$(VERSION) — Default left-click action" \
+	  --title "$(VERSION) — menuet v2.2.0 (interface MenuItem)" \
 	  --notes-file RELEASE_NOTES.md
 
 clean:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,14 @@
-## v0.8 — Default left-click action
+## v0.9 — menuet v2.2.0
 
-Pick a default duration from the new **Left-click** submenu, and from then on a single left-click on the menubar icon toggles caffeinate at that duration — no menu, no submenu. Right-click (or Ctrl-click) still opens the full menu.
+Maintenance bump. No user-visible changes — the app behaves the same as v0.8.
 
 ### What changed
-- New **"Left-click: …"** menu section. Choices: Off · Until I close the lid · Indefinitely · 10 / 30 / 60 / 180 min. Stored in NSUserDefaults; the current choice is shown in the parent label and persists across launches.
-- When a default is set, left-click *toggles*: if the Mac is being kept awake, the click cancels it; otherwise it starts a new session at the chosen duration. (Accidentally caffeinated → one click to undo.)
-- Picks up `menuet` v2.1.1 (new `Application.Clicked` field, plus the v2 Go module path fix).
-- Closes #2.
+- Picks up [menuet v2.2.0](https://github.com/caseymrm/menuet/releases/tag/v2.2.0), where `MenuItem` becomes a Go interface with `Regular` and `Separator` as the first two concrete implementations. All internal call sites migrated:
+  - `menuet.MenuItem{Text: …}` → `menuet.Regular{Text: …}`
+  - `menuet.MenuItem{Type: menuet.Separator}` → `menuet.Separator{}`
+- Slice element types in `[]menuet.MenuItem` literals are now qualified, as the new interface requires.
 
 ### Gatekeeper
 Still **unsigned** (ad-hoc only).
 1. Right-click `WhyAwake.app` → **Open** → confirm, **or**
 2. `xattr -dr com.apple.quarantine /Applications/WhyAwake.app` after copying to `/Applications`.
-
-### Install
-Download `WhyAwake.app.zip` → unzip → drag to `/Applications` → launch (see Gatekeeper note).

--- a/WhyAwake.app/Contents/Info.plist
+++ b/WhyAwake.app/Contents/Info.plist
@@ -13,7 +13,7 @@
   <key>CFBundleName</key>
   <string>WhyAwake</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.8</string>
+  <string>0.9</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundlePackageType</key>
@@ -21,7 +21,7 @@
   <key>IFMajorVersion</key>
   <integer>0</integer>
   <key>IFMinorVersion</key>
-  <integer>8</integer>
+  <integer>9</integer>
   <key>LSMinimumSystemVersion</key>
   <string>10.14</string>
   <key>NSHighResolutionCapable</key><true/>

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/caseymrm/go-caffeinate v1.0.0
 	github.com/caseymrm/go-clamshell v1.0.1
 	github.com/caseymrm/go-pmset v1.0.0
-	github.com/caseymrm/menuet/v2 v2.1.1
+	github.com/caseymrm/menuet/v2 v2.2.0
 )
 
 require github.com/caseymrm/askm v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,5 @@ github.com/caseymrm/go-clamshell v1.0.1 h1:BWUf0uIPyT/aQ+QNnKOuJeI6iwvW2xMxfiPGx
 github.com/caseymrm/go-clamshell v1.0.1/go.mod h1:EH815Qd3cw5WHTqwn4i+TtjTns9tlpn0v/Nf5PIhu/0=
 github.com/caseymrm/go-pmset v1.0.0 h1:iXc5GlLSqdR0C0GW9nvxvF02ynUkbeVNhAPoYPW+psg=
 github.com/caseymrm/go-pmset v1.0.0/go.mod h1:MYha1Z8OJEvuLrM+7xZGkPGwpkzJ5uZ+M89hJkQoFD4=
-github.com/caseymrm/menuet/v2 v2.1.1 h1:9Iv0bP40xYHZJySwIDljrWEGYf2bNd8J1NMgWNED11k=
-github.com/caseymrm/menuet/v2 v2.1.1/go.mod h1:ZFPTrTUdPWdVFjb6FQPbbDNtYD0X3/svM+QTkMYFHjM=
+github.com/caseymrm/menuet/v2 v2.2.0 h1:8PBcc1N6dLnaPnM2JeH4ea/5TGdELRslTRrywqiqRUc=
+github.com/caseymrm/menuet/v2 v2.2.0/go.mod h1:fw/xps1icldZXguIGgsokmkVgGd51N1h+X6evRuPv8s=

--- a/leftclick.go
+++ b/leftclick.go
@@ -99,7 +99,7 @@ func leftClickDefaultMenu() []menuet.MenuItem {
 	items := make([]menuet.MenuItem, len(leftClickChoices))
 	for i, c := range leftClickChoices {
 		stored := c.stored
-		items[i] = menuet.MenuItem{
+		items[i] = menuet.Regular{
 			Text:    c.label,
 			State:   current == stored,
 			Clicked: func() { setLeftClickStored(stored) },

--- a/sleep.go
+++ b/sleep.go
@@ -16,12 +16,12 @@ const lidMode = -1
 
 func sleepOptions() []menuet.MenuItem {
 	return []menuet.MenuItem{
-		{Text: "Until I close the lid", Clicked: func() { preventSleep(lidMode) }, State: sleepOptionSelected(lidMode)},
-		{Text: "Indefinitely", Clicked: func() { preventSleep(0) }, State: sleepOptionSelected(0)},
-		{Text: "10 minutes", Clicked: func() { preventSleep(10) }, State: sleepOptionSelected(10)},
-		{Text: "30 minutes", Clicked: func() { preventSleep(30) }, State: sleepOptionSelected(30)},
-		{Text: "1 hour", Clicked: func() { preventSleep(60) }, State: sleepOptionSelected(60)},
-		{Text: "3 hours", Clicked: func() { preventSleep(180) }, State: sleepOptionSelected(180)},
+		menuet.Regular{Text: "Until I close the lid", Clicked: func() { preventSleep(lidMode) }, State: sleepOptionSelected(lidMode)},
+		menuet.Regular{Text: "Indefinitely", Clicked: func() { preventSleep(0) }, State: sleepOptionSelected(0)},
+		menuet.Regular{Text: "10 minutes", Clicked: func() { preventSleep(10) }, State: sleepOptionSelected(10)},
+		menuet.Regular{Text: "30 minutes", Clicked: func() { preventSleep(30) }, State: sleepOptionSelected(30)},
+		menuet.Regular{Text: "1 hour", Clicked: func() { preventSleep(60) }, State: sleepOptionSelected(60)},
+		menuet.Regular{Text: "3 hours", Clicked: func() { preventSleep(180) }, State: sleepOptionSelected(180)},
 	}
 }
 

--- a/whyawake.go
+++ b/whyawake.go
@@ -34,16 +34,17 @@ func menuItems() []menuet.MenuItem {
 	items := make([]menuet.MenuItem, 0)
 
 	if preventingSleep() {
-		items = append(items, menuet.MenuItem{
+		items = append(items, menuet.Regular{
 			Text:     preventionRemaining(),
 			FontSize: 12,
 		})
-		items = append(items, menuet.MenuItem{
-			Text:    "Deactivate",
-			Clicked: cancelSleepPrevention,
-		}, menuet.MenuItem{
-			Type: menuet.Separator,
-		})
+		items = append(items,
+			menuet.Regular{
+				Text:    "Deactivate",
+				Clicked: cancelSleepPrevention,
+			},
+			menuet.Separator{},
+		)
 	}
 
 	processes := make([]menuet.MenuItem, 0)
@@ -54,7 +55,7 @@ func menuItems() []menuet.MenuItem {
 			if pid.PID == cafPID {
 				continue
 			}
-			processes = append(processes, menuet.MenuItem{
+			processes = append(processes, menuet.Regular{
 				Text: pid.Name,
 				Clicked: func() {
 					killProcess(pid.PID)
@@ -67,30 +68,26 @@ func menuItems() []menuet.MenuItem {
 		if len(processes) > 1 {
 			text = fmt.Sprintf("%d processes keeping your Mac awake", len(processes))
 		}
-		items = append(items, menuet.MenuItem{
+		items = append(items, menuet.Regular{
 			Text:     text,
 			FontSize: 12,
 		})
 		items = append(items, processes...)
 	} else if !preventingSleep() {
-		items = append(items, menuet.MenuItem{
+		items = append(items, menuet.Regular{
 			Text: "Your Mac can sleep",
 		})
 	}
 
-	items = append(items, menuet.MenuItem{
-		Type: menuet.Separator,
-	})
-	items = append(items, menuet.MenuItem{
+	items = append(items, menuet.Separator{})
+	items = append(items, menuet.Regular{
 		Text:     "Keep this Mac awake",
 		FontSize: 12,
 	})
 	items = append(items, sleepOptions()...)
 
-	items = append(items, menuet.MenuItem{
-		Type: menuet.Separator,
-	})
-	items = append(items, menuet.MenuItem{
+	items = append(items, menuet.Separator{})
+	items = append(items, menuet.Regular{
 		Text:     leftClickDefaultLabel(),
 		FontSize: 12,
 		Children: leftClickDefaultMenu,
@@ -157,7 +154,7 @@ func main() {
 	app.Name = "Why Awake?"
 	app.Label = "com.github.caseymrm.whyawake"
 	app.Children = menuItems
-	app.AutoUpdate.Version = "v0.8"
+	app.AutoUpdate.Version = "v0.9"
 	app.AutoUpdate.Repo = "caseymrm/whyawake"
 	refreshLeftClickHandler()
 	app.RunApplication()


### PR DESCRIPTION
## Summary
- Maintenance bump to [menuet v2.2.0](https://github.com/caseymrm/menuet/releases/tag/v2.2.0), where \`MenuItem\` becomes a Go interface with \`Regular\` and \`Separator\` as concrete implementations.
- Migrate all call sites:
  - \`menuet.MenuItem{Text: …}\` → \`menuet.Regular{Text: …}\`
  - \`menuet.MenuItem{Type: menuet.Separator}\` → \`menuet.Separator{}\`
- Slice element types in \`[]menuet.MenuItem\` literals are now qualified.
- No user-visible behavioral changes.

## Test plan
- [x] Universal build: \`lipo -info\` → x86_64 arm64
- [x] App launches and stays running on Apple Silicon
- [ ] Menu rendering looks unchanged from v0.8 (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)