### PR TITLE
Add web-preview target + menuet-demo.json snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,20 @@ ARM64_MIN=11.0
 GO=go
 GOFLAGS=-trimpath -ldflags="-s -w"
 
-.PHONY: all amd64 arm64 universal app sign notarize zip release clean
+.PHONY: all amd64 arm64 universal app sign notarize zip release clean web-preview
 
 all: app
 
 $(BUILD):
 	mkdir -p $(BUILD)
+
+# Capture a JSON snapshot of the running menu for the menuet.app showcase.
+# Override MENUET_SNAPSHOT_DELAY to give startup goroutines more time to
+# populate state (default is 2s).
+web-preview: $(BUILD)
+	$(GO) build $(GOFLAGS) -o $(BUILD)/$(EXE)-snapshot .
+	MENUET_SNAPSHOT_PATH=menuet-demo.json $(BUILD)/$(EXE)-snapshot
+	@echo "Wrote menuet-demo.json"
 
 amd64: $(BUILD)
 	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 \

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/caseymrm/go-caffeinate v1.0.0
 	github.com/caseymrm/go-clamshell v1.0.1
 	github.com/caseymrm/go-pmset v1.0.0
-	github.com/caseymrm/menuet/v2 v2.2.0
+	github.com/caseymrm/menuet/v2 v2.10.0
 )
 
 require github.com/caseymrm/askm v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,5 @@ github.com/caseymrm/go-pmset v1.0.0 h1:iXc5GlLSqdR0C0GW9nvxvF02ynUkbeVNhAPoYPW+p
 github.com/caseymrm/go-pmset v1.0.0/go.mod h1:MYha1Z8OJEvuLrM+7xZGkPGwpkzJ5uZ+M89hJkQoFD4=
 github.com/caseymrm/menuet/v2 v2.2.0 h1:8PBcc1N6dLnaPnM2JeH4ea/5TGdELRslTRrywqiqRUc=
 github.com/caseymrm/menuet/v2 v2.2.0/go.mod h1:fw/xps1icldZXguIGgsokmkVgGd51N1h+X6evRuPv8s=
+github.com/caseymrm/menuet/v2 v2.10.0 h1:MEaqxSWOEMRrwcZuSpAhnUCaWFev61E1q1H+jhJzYz8=
+github.com/caseymrm/menuet/v2 v2.10.0/go.mod h1:fw/xps1icldZXguIGgsokmkVgGd51N1h+X6evRuPv8s=

--- a/menuet-demo.json
+++ b/menuet-demo.json
@@ -1,0 +1,193 @@
+{
+  "schema": "menuet-snapshot/v1",
+  "state": {
+    "Title": "",
+    "Runs": null,
+    "Image": "Eye.pdf"
+  },
+  "items": [
+    {
+      "type": "regular",
+      "text": "Your Mac can sleep",
+      "color": {
+        "R": 0,
+        "G": 0,
+        "B": 0,
+        "A": 0
+      }
+    },
+    {
+      "type": "separator",
+      "color": {
+        "R": 0,
+        "G": 0,
+        "B": 0,
+        "A": 0
+      }
+    },
+    {
+      "type": "regular",
+      "text": "Keep this Mac awake",
+      "fontSize": 12,
+      "color": {
+        "R": 0,
+        "G": 0,
+        "B": 0,
+        "A": 0
+      }
+    },
+    {
+      "type": "regular",
+      "text": "Until I close the lid",
+      "color": {
+        "R": 0,
+        "G": 0,
+        "B": 0,
+        "A": 0
+      }
+    },
+    {
+      "type": "regular",
+      "text": "Indefinitely",
+      "color": {
+        "R": 0,
+        "G": 0,
+        "B": 0,
+        "A": 0
+      }
+    },
+    {
+      "type": "regular",
+      "text": "10 minutes",
+      "color": {
+        "R": 0,
+        "G": 0,
+        "B": 0,
+        "A": 0
+      }
+    },
+    {
+      "type": "regular",
+      "text": "30 minutes",
+      "color": {
+        "R": 0,
+        "G": 0,
+        "B": 0,
+        "A": 0
+      }
+    },
+    {
+      "type": "regular",
+      "text": "1 hour",
+      "color": {
+        "R": 0,
+        "G": 0,
+        "B": 0,
+        "A": 0
+      }
+    },
+    {
+      "type": "regular",
+      "text": "3 hours",
+      "color": {
+        "R": 0,
+        "G": 0,
+        "B": 0,
+        "A": 0
+      }
+    },
+    {
+      "type": "separator",
+      "color": {
+        "R": 0,
+        "G": 0,
+        "B": 0,
+        "A": 0
+      }
+    },
+    {
+      "type": "regular",
+      "text": "Left-click: Off",
+      "fontSize": 12,
+      "color": {
+        "R": 0,
+        "G": 0,
+        "B": 0,
+        "A": 0
+      },
+      "children": [
+        {
+          "type": "regular",
+          "text": "Off",
+          "color": {
+            "R": 0,
+            "G": 0,
+            "B": 0,
+            "A": 0
+          },
+          "state": true
+        },
+        {
+          "type": "regular",
+          "text": "Until I close the lid",
+          "color": {
+            "R": 0,
+            "G": 0,
+            "B": 0,
+            "A": 0
+          }
+        },
+        {
+          "type": "regular",
+          "text": "Indefinitely",
+          "color": {
+            "R": 0,
+            "G": 0,
+            "B": 0,
+            "A": 0
+          }
+        },
+        {
+          "type": "regular",
+          "text": "10 minutes",
+          "color": {
+            "R": 0,
+            "G": 0,
+            "B": 0,
+            "A": 0
+          }
+        },
+        {
+          "type": "regular",
+          "text": "30 minutes",
+          "color": {
+            "R": 0,
+            "G": 0,
+            "B": 0,
+            "A": 0
+          }
+        },
+        {
+          "type": "regular",
+          "text": "1 hour",
+          "color": {
+            "R": 0,
+            "G": 0,
+            "B": 0,
+            "A": 0
+          }
+        },
+        {
+          "type": "regular",
+          "text": "3 hours",
+          "color": {
+            "R": 0,
+            "G": 0,
+            "B": 0,
+            "A": 0
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Bump menuet from v2.2.0 → v2.10.0 (snapshot mode landed in v2.10.0)
- Add `make web-preview` target that runs the binary in snapshot mode and writes `menuet-demo.json`
- Commit a captured snapshot so menuet.app can render whyawake's menu in its "Apps built with menuet" showcase

The snapshot mode is gated by the `MENUET_SNAPSHOT_PATH` env var — normal builds and runs are unaffected.

## Test plan

- [x] `go build` still works
- [x] `make web-preview` produces valid JSON matching the menuet-snapshot/v1 schema